### PR TITLE
Page actions for anon and no blank target for external link

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -183,7 +183,7 @@ $wgCitizenButtonLink = 'https://discord.gg/3kjftWK';
 $wgCitizenButtonTitle = 'Contact us on Discord';
 $wgCitizenButtonText = 'Discord';
 # Page tools
-$wgCitizenShowPageTools = 'login'; #Only show page tools if logged in
+#$wgCitizenShowPageTools = 'login'; #Only show page tools if logged in
 # Search description source
 $wgCitizenSearchDescriptionSource = 'wikidata';
 # Number of search results in suggestion

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -198,7 +198,8 @@ $wgAllowTitlesInSVG = true;
 $wgSVGConverter = 'ImageMagick';
 
 #Open external link in new tab/window
-$wgExternalLinkTarget = '_blank';
+#Disabled due to security issue (Links to cross-origin destinations are unsafe)
+#$wgExternalLinkTarget = '_blank';
 
 #=============================================== External Includes ===============================================
 


### PR DESCRIPTION
- Removed blank target for external link due to security implications
- Make page action visible for anon as well to encourage editing
EDIT: Is there anyway to decouple the submodule commit?